### PR TITLE
docs: update README badges to match repo standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![NuGet](https://img.shields.io/nuget/v/ErikLieben.FA.Results?style=flat-square)](https://www.nuget.org/packages/ErikLieben.FA.Results)
 [![Changelog](https://img.shields.io/badge/Changelog-releases-informational?style=flat-square)](https://github.com/eriklieben/ErikLieben.FA.Results/releases)
-[![.NET 10.0](https://img.shields.io/badge/.NET-10.0-blue?style=flat-square)](https://dotnet.microsoft.com/download/dotnet/10.0)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eriklieben/ErikLieben.FA.Results/badge)](https://scorecard.dev/viewer/?uri=github.com/eriklieben/ErikLieben.FA.Results)
+[![.NET 8.0 | 9.0 | 10.0](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C%2010.0-blue?style=flat-square)](https://dotnet.microsoft.com)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eriklieben_ErikLieben.FA.Results&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=eriklieben_ErikLieben.FA.Results)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=eriklieben_ErikLieben.FA.Results&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=eriklieben_ErikLieben.FA.Results)
@@ -40,7 +40,7 @@ Perfect for **domain modeling**, collecting validation errors, and consistent AP
 dotnet add package ErikLieben.FA.Results
 ```
 
-**Requirements:** .NET 9.0+
+**Requirements:** .NET 8.0+
 
 ## 🗂️ Core Concepts
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![NuGet](https://img.shields.io/nuget/v/ErikLieben.FA.Results?style=flat-square)](https://www.nuget.org/packages/ErikLieben.FA.Results)
 [![Changelog](https://img.shields.io/badge/Changelog-releases-informational?style=flat-square)](https://github.com/eriklieben/ErikLieben.FA.Results/releases)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eriklieben/ErikLieben.FA.Results/badge)](https://scorecard.dev/viewer/?uri=github.com/eriklieben/ErikLieben.FA.Results)
 [![.NET 8.0 | 9.0 | 10.0](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C%2010.0-blue?style=flat-square)](https://dotnet.microsoft.com)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eriklieben_ErikLieben.FA.Results&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=eriklieben_ErikLieben.FA.Results)
@@ -12,6 +11,7 @@
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=eriklieben_ErikLieben.FA.Results&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=eriklieben_ErikLieben.FA.Results)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=eriklieben_ErikLieben.FA.Results&metric=coverage)](https://sonarcloud.io/summary/new_code?id=eriklieben_ErikLieben.FA.Results)
 [![Known Vulnerabilities](https://snyk.io/test/github/eriklieben/ErikLieben.FA.Results/badge.svg)](https://snyk.io/test/github/eriklieben/ErikLieben.FA.Results)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/eriklieben/ErikLieben.FA.Results/badge)](https://scorecard.dev/viewer/?uri=github.com/eriklieben/ErikLieben.FA.Results)
 
 
 > **A lightweight, allocation-friendly Result type for .NET that makes success/failure flow explicit, composable, and ergonomic.**


### PR DESCRIPTION
## Summary

- Reorder badges: OpenSSF Scorecard before .NET version (matching other repos)
- Update .NET badge from 10.0 to 8.0 | 9.0 | 10.0
- Update requirements text to .NET 8.0+